### PR TITLE
Check ID of uid rather than iid in getRecItemsTopN

### DIFF
--- a/predictionio.js
+++ b/predictionio.js
@@ -175,7 +175,7 @@ PredictionIO.Client.prototype.getRecItemsTopN = function(params, cb){
 	var engineName = params.engine_name;
 	delete params.engine_name;
 
-	checkId(params, 'pio_iid');
+	checkId(params, 'pio_uid');
 	check(engineName, String);
 	check(params.pio_n, Number);
 


### PR DESCRIPTION
pio_iid is not available in in the getRecItemsTopN function.
